### PR TITLE
Splitquote now returns multiple order ids

### DIFF
--- a/Plugin/SplitQuote.php
+++ b/Plugin/SplitQuote.php
@@ -75,7 +75,7 @@ class SplitQuote
 
         // Separate all items in quote into new quotes.
         if (($quotes = $this->quoteHandler->normalizeQuotes($quote)) === false) {
-            return $result = $proceed($cartId, $payment);
+            return $result = array_values([($proceed($cartId, $payment))]);
         }
         // Collect list of data addresses.
         $addresses = $this->quoteHandler->collectAddressesData($quote);
@@ -130,7 +130,11 @@ class SplitQuote
             'checkout_submit_all_after',
             ['orders' => $orders, 'quote' => $quote]
         );
-        return $order->getId();
+        $order_ids = array();
+        foreach(array_keys($orderIds) as $orderKey) {
+            $order_ids[] = (string)$orderKey;
+        };
+        return array_values($order_ids);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magestat.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The rest API endpoints for creating orders from a quote/cart return just a single order ID, instead of a list of orders created from the original cart.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magestat/magento2-split-order#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magestat/magento2-split-order#11 (https://github.com/magestat/magento2-split-order/issues/11)

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add multiple items to a cart.
2. Ensure that the plugin is enabled.
3. Create an order via the REST endpoint. v1/carts/:cartID/order

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
