### PR TITLE
Issue #16 and #20: Fix issue with totals & Improve PHPDocs

### DIFF
--- a/Api/QuoteHandlerInterface.php
+++ b/Api/QuoteHandlerInterface.php
@@ -20,30 +20,30 @@ interface QuoteHandlerInterface
     /**
      * Separate all items in quote into new quotes.
      *
-     * @param object $quote
-     * @return array
+     * @param \Magento\Quote\Model\Quote $quote
+     * @return bool|array False if not split, or an array of array of split items
      */
     public function normalizeQuotes($quote);
 
     /**
-     * @param object $product
+     * @param \Magento\Catalog\Model\Product $product
      * @param string $attributes
-     * @return string
+     * @return mixed
      */
     public function getProductAttributes($product, $attributes);
 
     /**
      * Collect list of data addresses.
      *
-     * @param object $quote
+     * @param \Magento\Quote\Model\Quote $quote
      * @return array
      */
     public function collectAddressesData($quote);
 
     /**
-     * @param object $quote
-     * @param object $split
-     * @return $this
+     * @param \Magento\Quote\Model\Quote $quote
+     * @param \Magento\Quote\Model\Quote $split
+     * @return \Magestat\SplitOrder\Api\QuoteHandlerInterface
      */
     public function setCustomerData($quote, $split);
  
@@ -51,49 +51,49 @@ interface QuoteHandlerInterface
      * Populate quotes with new data.
      *
      * @param array $quotes
-     * @param object $split
-     * @param object $item
+     * @param \Magento\Quote\Model\Quote $split
+     * @param \Magento\Quote\Model\Quote\Item[] $items
      * @param array $addresses
      * @param string $payment
-     * @return $this
+     * @return \Magestat\SplitOrder\Api\QuoteHandlerInterface
      */
-    public function populateQuote($quotes, $split, $item, $addresses, $payment);
+    public function populateQuote($quotes, $split, $items, $addresses, $payment);
 
     /**
      * Recollect order totals.
      *
-     * @param object $quotes
+     * @param array $quotes
      * @param \Magento\Quote\Model\Quote\Item[] $items
-     * @param object $quote
+     * @param \Magento\Quote\Model\Quote $quote
      * @param array $addresses
-     * @return $this
+     * @return \Magestat\SplitOrder\Api\QuoteHandlerInterface
      */
     public function recollectTotal($quotes, $items, $quote, $addresses);
  
     /**
-     * @param object $quotes
-     * @param object $quote
+     * @param array $quotes
+     * @param \Magento\Quote\Model\Quote $quote
      * @param float $total
      */
-    public function shippingAmount($quotes, $quote, $total = 0);
+    public function shippingAmount($quotes, $quote, $total = 0.0);
     
     /**
      * Set payment method.
      *
-     * @param object $paymentMethod
-     * @param object $split
+     * @param string $paymentMethod
+     * @param \Magento\Quote\Model\Quote $split
      * @param string $payment
-     * @return $this
+     * @return \Magestat\SplitOrder\Api\QuoteHandlerInterface
      */
     public function setPaymentMethod($paymentMethod, $split, $payment);
 
     /**
      * Define checkout sessions.
      *
-     * @param object $split
-     * @param object $order
+     * @param \Magento\Quote\Model\Quote $split
+     * @param \Magento\Sales\Model\Order $order
      * @param array $orderIds
-     * @return $this
+     * @return \Magestat\SplitOrder\Api\QuoteHandlerInterface
      */
     public function defineSessions($split, $order, $orderIds);
 }

--- a/Api/QuoteHandlerInterface.php
+++ b/Api/QuoteHandlerInterface.php
@@ -50,7 +50,7 @@ interface QuoteHandlerInterface
     /**
      * Populate quotes with new data.
      *
-     * @param object $quotes
+     * @param array $quotes
      * @param object $split
      * @param object $item
      * @param array $addresses
@@ -63,12 +63,12 @@ interface QuoteHandlerInterface
      * Recollect order totals.
      *
      * @param object $quotes
-     * @param object $item
+     * @param \Magento\Quote\Model\Quote\Item[] $items
      * @param object $quote
      * @param array $addresses
      * @return $this
      */
-    public function recollectTotal($quotes, $item, $quote, $addresses);
+    public function recollectTotal($quotes, $items, $quote, $addresses);
  
     /**
      * @param object $quotes

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -52,7 +52,7 @@ class Success extends \Magento\Checkout\Block\Onepage\Success
     }
 
     /**
-     * @return boolean|array
+     * @return bool|array
      */
     public function getOrderArray()
     {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -19,7 +19,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Check if module is active.
      *
-     * @param null $storeId
+     * @param int $storeId
      * @return bool
      */
     public function isActive($storeId = null)
@@ -34,8 +34,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get attributes to split.
      *
-     * @param null $storeId
-     * @return array
+     * @param int $storeId
+     * @return string
      */
     public function getAttributes($storeId = null)
     {
@@ -49,12 +49,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Check if should split delivery.
      *
-     * @param null $storeId
+     * @param string $storeId
      * @return bool
      */
     public function getShippingSplit($storeId = null)
     {
-        return $this->scopeConfig->getValue(
+        return (bool) $this->scopeConfig->getValue(
             'magestat_split_order/options/shipping',
             ScopeInterface::SCOPE_STORE,
             $storeId

--- a/Model/Config/Source/Attributes.php
+++ b/Model/Config/Source/Attributes.php
@@ -42,6 +42,7 @@ class Attributes implements ArrayInterface
     /**
      * Get options as array
      *
+     * @param bool $isMultiselect
      * @return array
      */
     public function toOptionArray($isMultiselect = false)

--- a/Model/QuoteHandler.php
+++ b/Model/QuoteHandler.php
@@ -143,13 +143,19 @@ class QuoteHandler implements QuoteHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function recollectTotal($quotes, $item, $quote, $addresses)
+    public function recollectTotal($quotes, $items, $quote, $addresses)
     {
-        // Retrieve values.
-        $tax = $item->getData('tax_amount');
-        $discount = $item->getData('discount_amount');
+        $tax = 0.0;
+        $discount = 0.0;
+        $finalPrice = 0.0;
 
-        $finalPrice = ($item->getPrice() * $item->getQty());
+        foreach ($items as $item) {
+            // Retrieve values.
+            $tax += $item->getData('tax_amount');
+            $discount += $item->getData('discount_amount');
+
+            $finalPrice += ($item->getPrice() * $item->getQty());
+        }
 
         // Set addresses.
         $quote->getBillingAddress()->setData($addresses['billing']);

--- a/Model/QuoteHandler.php
+++ b/Model/QuoteHandler.php
@@ -131,9 +131,9 @@ class QuoteHandler implements QuoteHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function populateQuote($quotes, $split, $item, $addresses, $payment)
+    public function populateQuote($quotes, $split, $items, $addresses, $payment)
     {
-        $this->recollectTotal($quotes, $item, $split, $addresses);
+        $this->recollectTotal($quotes, $items, $split, $addresses);
         // Set payment method.
         $this->setPaymentMethod($split, $addresses['payment'], $payment);
 
@@ -183,7 +183,7 @@ class QuoteHandler implements QuoteHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function shippingAmount($quotes, $quote, $total = 0)
+    public function shippingAmount($quotes, $quote, $total = 0.0)
     {
         // Add shipping amount if product is not virual.
         if ($quote->hasVirtualItems() === true) {

--- a/Plugin/SplitQuote.php
+++ b/Plugin/SplitQuote.php
@@ -140,7 +140,7 @@ class SplitQuote
      * Save quote
      *
      * @param \Magento\Quote\Api\Data\CartInterface $quote
-     * @return \Magestat\SplitOrder\Plugin\SplitQuote $this
+     * @return \Magestat\SplitOrder\Plugin\SplitQuote
      */
     private function toSaveQuote($quote)
     {

--- a/Plugin/SplitQuote.php
+++ b/Plugin/SplitQuote.php
@@ -101,7 +101,7 @@ class SplitQuote
                 $split->addItem($item);
             }
             // Recollect order totals.
-            $this->quoteHandler->populateQuote($quotes, $split, $item, $addresses, $payment);
+            $this->quoteHandler->populateQuote($quotes, $split, $items, $addresses, $payment);
 
             // Dispatch event as Magento standard once per each quote split.
             $this->eventManager->dispatch(


### PR DESCRIPTION
### Description
When there are multiple products in the split orders, the totals are not calculated correctly.

### Fixed Issues (if relevant)
1. magestat/magento2-split-order#16: If multiple products in cart from same vendor giving wrong totals
2. magestat/magento2-split-order#20: PHPDocs for most functions are incorrect/could be improved

### Manual testing scenarios
Step 1 : Add 4 to 5 products in admin products catalog
Step 2 : Change weight of the products as 0.45 to 3 products and 0.56 to remaining products
Step 3 : In Split Order module configurations Select "Weight" attribute to split the order
Step 4 : Navigate to the front end and add all these 5 products to cart
Step 5 : Checkout and place an order . You can get 2 orders.
Step 6 : Check the subtotals and tax information

Before fix:
![image](https://user-images.githubusercontent.com/11316647/57576063-14ee7400-742e-11e9-984a-f52b86650d3f.png)

After fix:
![image](https://user-images.githubusercontent.com/11316647/57576067-1fa90900-742e-11e9-8d69-8e192486bb6c.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
