### PR TITLE
[26] Split Order Based on the product Stock Status

### DIFF
--- a/Api/ExtensionAttributesInterface.php
+++ b/Api/ExtensionAttributesInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * A Magento 2 module named Magestat/SplitOrder
+ * Copyright (C) 2018 Magestat
+ *
+ * This file included in Magestat/SplitOrder is licensed under OSL 3.0
+ *
+ * http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * Please see LICENSE.txt for the full text of the OSL 3.0 license
+ */
+
+namespace Magestat\SplitOrder\Api;
+
+/**
+ * Interface ExtensionAttributesInterface
+ * @package Magestat\SplitOrder\Api
+ * @api
+ */
+interface ExtensionAttributesInterface
+{
+    /**
+     * @var string
+     */
+    const QUANTITY_AND_STOCK_STATUS = 'quantity_and_stock_status';
+
+    /**
+     * Method to cover extra attributes which need a different load model.
+     *
+     * @param \Magento\Catalog\Model\Product $product
+     * @param string $attributeCode
+     * @return bool|string
+     */
+    public function loadValue($product, $attributeCode);
+
+    /**
+     * Handle Stock attribute data.
+     *
+     * @param \Magento\Catalog\Api\Data\ProductExtensionInterface $attributes
+     * @return string|float
+     */
+    public function quantityAndStockStatus($attributes);
+}

--- a/Api/QuoteHandlerInterface.php
+++ b/Api/QuoteHandlerInterface.php
@@ -27,10 +27,10 @@ interface QuoteHandlerInterface
 
     /**
      * @param \Magento\Catalog\Model\Product $product
-     * @param string $attributes
-     * @return mixed
+     * @param string $attributeCode
+     * @return string
      */
-    public function getProductAttributes($product, $attributes);
+    public function getProductAttributes($product, $attributeCode);
 
     /**
      * Collect list of data addresses.

--- a/Api/QuoteHandlerInterface.php
+++ b/Api/QuoteHandlerInterface.php
@@ -91,7 +91,7 @@ interface QuoteHandlerInterface
      * Define checkout sessions.
      *
      * @param \Magento\Quote\Model\Quote $split
-     * @param \Magento\Sales\Model\Order $order
+     * @param \Magento\Framework\Model\AbstractExtensibleModel|\Magento\Sales\Api\Data\OrderInterface|object|null $order
      * @param array $orderIds
      * @return \Magestat\SplitOrder\Api\QuoteHandlerInterface
      */

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -56,15 +56,12 @@ class Success extends \Magento\Checkout\Block\Onepage\Success
      */
     public function getOrderArray()
     {
-        $splittedOrders = $this->checkoutSession->getOrderIds();
-        // Remove session.
+        $splitOrders = $this->checkoutSession->getOrderIds();
         $this->checkoutSession->unsOrderIds();
 
-        // If number of orders is just like one, kill function.
-        if (count($splittedOrders) <= 1) {
+        if (empty($splitOrders) || count($splitOrders) <= 1) {
             return false;
         }
-        // Return prepared block data.
-        return $splittedOrders;
+        return $splitOrders;
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -54,8 +54,38 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getShippingSplit($storeId = null)
     {
-        return (bool) $this->scopeConfig->getValue(
+        return (bool) $this->scopeConfig->isSetFlag(
             'magestat_split_order/options/shipping',
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * Get which kind of attribute related with qty should be load.
+     *
+     * @param int $storeId
+     * @return bool
+     */
+    public function getQtyType($storeId = null)
+    {
+        return $this->scopeConfig->getValue(
+            'magestat_split_order/options/attribute_qty',
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * If should apply out of stock if inventory is empty.
+     *
+     * @param int $storeId
+     * @return string
+     */
+    public function getBackorder($storeId = null)
+    {
+        return (bool) $this->scopeConfig->isSetFlag(
+            'magestat_split_order/options/qty_backorder',
             ScopeInterface::SCOPE_STORE,
             $storeId
         );

--- a/Model/Config/Source/AttributeQty.php
+++ b/Model/Config/Source/AttributeQty.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * A Magento 2 module named Magestat/SplitOrder
+ * Copyright (C) 2018 Magestat
+ *
+ * This file included in Magestat/SplitOrder is licensed under OSL 3.0
+ *
+ * http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * Please see LICENSE.txt for the full text of the OSL 3.0 license
+ */
+
+namespace Magestat\SplitOrder\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory;
+
+/**
+ * @package Magestat\SplitOrder\Model\Config\Source
+ */
+class AttributeQty implements OptionSourceInterface
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            'qty' => __('Stock Quantity (Inventory value)'),
+            'status' => __('Stock Status (In or Out of stock)')
+        ];
+    }
+}

--- a/Model/Config/Source/Attributes.php
+++ b/Model/Config/Source/Attributes.php
@@ -12,14 +12,37 @@
 
 namespace Magestat\SplitOrder\Model\Config\Source;
 
-use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\Data\OptionSourceInterface;
 use Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory;
 
 /**
  * @package Magestat\SplitOrder\Model\Config\Source
  */
-class Attributes implements ArrayInterface
+class Attributes implements OptionSourceInterface
 {
+    /**
+     * @var array List of attributes that shouldn't appear on the list.
+     */
+    const BLACK_LIST = [
+        'custom_design',
+        'custom_design_from',
+        'custom_design_to',
+        'custom_layout_update',
+        'page_layout',
+        'gallery',
+        'image',
+        'image_label',
+        'small_image',
+        'small_image_label',
+        'thumbnail',
+        'thumbnail_label',
+        'swatch_image',
+        'links_exist',
+        'media_gallery',
+        'old_id',
+        'required_options',
+    ];
+
     /**
      * @var \Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory
      */
@@ -42,26 +65,30 @@ class Attributes implements ArrayInterface
     /**
      * Get options as array
      *
-     * @param bool $isMultiselect
      * @return array
      */
-    public function toOptionArray($isMultiselect = false)
+    public function toOptionArray()
     {
-        if (!$this->options) {
-            $collection = $this->collection->create();
+        if ($this->options) {
+            return $this->options;
+        }
+        $collection = $this->collection->create();
 
-            foreach ($collection as $items) {
-                $attributes[] = [
-                    'value' => $items->getAttributeCode(),
-                    'label' => $items->getFrontendLabel()
-                ];
+        $attributes = [];
+        foreach ($collection as $item) {
+            if (empty($item->getFrontendLabel()) || in_array($item->getAttributeCode(), self::BLACK_LIST)) {
+                continue;
             }
-            $this->options = $attributes;
+            $attributes[] = [
+                'value' => $item->getAttributeCode(),
+                'label' => $item->getFrontendLabel()
+            ];
         }
+        $this->options = $attributes;
+
         $options = $this->options;
-        if (!$isMultiselect) {
-            array_unshift($options, ['value' => '', 'label' => __('--Please Select--')]);
-        }
+        array_unshift($options, ['value' => '', 'label' => __('--Please Select--')]);
+
         return $options;
     }
 }

--- a/Model/ExtensionAttributes.php
+++ b/Model/ExtensionAttributes.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * A Magento 2 module named Magestat/SplitOrder
+ * Copyright (C) 2018 Magestat
+ *
+ * This file included in Magestat/SplitOrder is licensed under OSL 3.0
+ *
+ * http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * Please see LICENSE.txt for the full text of the OSL 3.0 license
+ */
+
+namespace Magestat\SplitOrder\Model;
+
+use Magestat\SplitOrder\Helper\Data as HelperData;
+use Magestat\SplitOrder\Api\ExtensionAttributesInterface;
+
+/**
+ * Class ExtensionAttributes
+ * @package Magestat\SplitOrder\Model
+ */
+class ExtensionAttributes implements ExtensionAttributesInterface
+{
+    /**
+     * @var \Magestat\SplitOrder\Helper\Data
+     */
+    private $helperData;
+
+    /**
+     * @param HelperData $helperData
+     */
+    public function __construct(
+        HelperData $helperData
+    ) {
+        $this->helperData = $helperData;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function loadValue($product, $attributeCode)
+    {
+        /** @var \Magento\Catalog\Api\Data\ProductExtensionInterface $attributes */
+        $attributes = $product->getExtensionAttributes();
+        if ($attributeCode === self::QUANTITY_AND_STOCK_STATUS) {
+            return (string) $this->quantityAndStockStatus($attributes);
+        }
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function quantityAndStockStatus($attributes)
+    {
+        if ($this->helperData->getQtyType() === 'qty') {
+            return $attributes->getStockItem()->getQty();
+        }
+        if ($this->helperData->getBackorder() && $attributes->getStockItem()->getQty() < 0) {
+            return 'out';
+        }
+        return ($attributes->getStockItem()->getIsInStock()) ? 'in' : 'out';
+    }
+}

--- a/Model/QuoteHandler.php
+++ b/Model/QuoteHandler.php
@@ -50,7 +50,6 @@ class QuoteHandler implements QuoteHandlerInterface
      */
     public function normalizeQuotes($quote)
     {
-        // if module is active.
         if (!$this->helperData->isActive()) {
             return false;
         }
@@ -65,7 +64,6 @@ class QuoteHandler implements QuoteHandlerInterface
 
             $attribute = $this->getProductAttributes($product, $attributes);
             if (empty($attribute)) {
-                // Kill function if attribute is null.
                 return false;
             }
             $groups[$attribute][] = $item;
@@ -80,14 +78,15 @@ class QuoteHandler implements QuoteHandlerInterface
     /**
      * @inheritdoc
      */
-    public function getProductAttributes($product, $attributes)
+    public function getProductAttributes($product, $attributeCode)
     {
-        $attribute = $product->getResource()
-            ->getAttribute($attributes)
-            ->getFrontend()
-            ->getValue($product);
+        $attributeObject = $product->getResource()->getAttribute($attributeCode);
 
-        return $attribute;
+        $attributeValue = $attributeObject->getFrontend()->getValue($product);
+        if ($attributeValue instanceof \Magento\Framework\Phrase) {
+            return $attributeValue->__toString();
+        }
+        return $attributeValue;
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,7 +33,23 @@
                     <source_model>Magestat\SplitOrder\Model\Config\Source\Attributes</source_model>
                     <comment>Select an attribute to be compared, will be split products with different attribute values.</comment>
                 </field>
-                <field id="shipping" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="attribute_qty" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Type of Stock Attribute</label>
+                    <source_model>Magestat\SplitOrder\Model\Config\Source\AttributeQty</source_model>
+                    <comment>You can select which type of value should be returned.</comment>
+                    <depends>
+                        <field id="attributes">quantity_and_stock_status</field>
+                    </depends>
+                </field>
+                <field id="qty_backorder" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Backorder option</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Set product Out of Stock when Backorder is enabled and inventory number is less than zero.</comment>
+                    <depends>
+                        <field id="attribute_qty">status</field>
+                    </depends>
+                </field>
+                <field id="shipping" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Split Shipping Total</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Split shipping total between orders, otherwise, place shipping total to one order only.</comment>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <!-- API Preferences -->
     <preference for="Magestat\SplitOrder\Api\QuoteHandlerInterface" type="Magestat\SplitOrder\Model\QuoteHandler"/>
+    <preference for="Magestat\SplitOrder\Api\ExtensionAttributesInterface" type="Magestat\SplitOrder\Model\ExtensionAttributes"/>
 
     <!-- Plugins -->
     <type name="Magento\Quote\Model\QuoteManagement">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magestat.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magestat/magento2-split-order#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magestat/magento2-split-order/issues/26: Splitting Order Based on Stock Status of product in the cart

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
